### PR TITLE
[Featuare] 닉네임, 비밀번호 유효성 검사 기능 구현

### DIFF
--- a/src/main/java/org/triumers/newsnippetback/Application/controller/AuthController.java
+++ b/src/main/java/org/triumers/newsnippetback/Application/controller/AuthController.java
@@ -106,7 +106,7 @@ public class AuthController {
 
         } catch (ExpiredJwtException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseMessageVO("[ERROR] 로그인 이후 이용해주십시오."));
-        } catch (WrongPasswordException e) {
+        } catch (WrongPasswordException | WrongInputTypeException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseMessageVO(e.getMessage()));
         }
     }

--- a/src/main/java/org/triumers/newsnippetback/Application/controller/AuthController.java
+++ b/src/main/java/org/triumers/newsnippetback/Application/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.triumers.newsnippetback.Application.service.AuthService;
 import org.triumers.newsnippetback.common.exception.UserEmailDuplicateException;
 import org.triumers.newsnippetback.common.exception.UserNicknameDuplicateException;
+import org.triumers.newsnippetback.common.exception.WrongInputTypeException;
 import org.triumers.newsnippetback.common.exception.WrongPasswordException;
 import org.triumers.newsnippetback.domain.aggregate.enums.Provider;
 import org.triumers.newsnippetback.domain.aggregate.vo.RequestModifyPasswordVO;
@@ -45,7 +46,7 @@ public class AuthController {
         try {
             authService.signup(user);
 
-        } catch (UserNicknameDuplicateException | UserEmailDuplicateException e) {
+        } catch (UserNicknameDuplicateException | UserEmailDuplicateException | WrongInputTypeException e) {
 
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseMessageVO(e.getMessage()));
         }
@@ -89,8 +90,8 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessageVO("변경 성공"));
         } catch (ExpiredJwtException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseMessageVO("[ERROR] 로그인 이후 이용해주십시오."));
-        } catch (UserNicknameDuplicateException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseMessageVO("[ERROR] 이미 존재하는 닉네임입니다."));
+        } catch (UserNicknameDuplicateException | WrongInputTypeException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseMessageVO(e.getMessage()));
         }
     }
 

--- a/src/main/java/org/triumers/newsnippetback/Application/service/AuthService.java
+++ b/src/main/java/org/triumers/newsnippetback/Application/service/AuthService.java
@@ -2,6 +2,7 @@ package org.triumers.newsnippetback.Application.service;
 
 import org.triumers.newsnippetback.common.exception.UserEmailDuplicateException;
 import org.triumers.newsnippetback.common.exception.UserNicknameDuplicateException;
+import org.triumers.newsnippetback.common.exception.WrongInputTypeException;
 import org.triumers.newsnippetback.common.exception.WrongPasswordException;
 import org.triumers.newsnippetback.domain.dto.AuthDTO;
 import org.triumers.newsnippetback.domain.dto.PasswordDTO;
@@ -9,13 +10,13 @@ import org.triumers.newsnippetback.domain.dto.UserDTO;
 
 public interface AuthService {
 
-    void signup(AuthDTO request) throws UserNicknameDuplicateException, UserEmailDuplicateException;
+    void signup(AuthDTO request) throws UserNicknameDuplicateException, UserEmailDuplicateException, WrongInputTypeException;
 
     boolean existNickname(String nickname);
 
     boolean existEmail(String email);
 
-    void modifyUserInfo(UserDTO userDTO) throws UserNicknameDuplicateException;
+    void modifyUserInfo(UserDTO userDTO) throws UserNicknameDuplicateException, WrongInputTypeException;
 
     void modifyPassword(PasswordDTO passwordDTO) throws WrongPasswordException;
 }

--- a/src/main/java/org/triumers/newsnippetback/Application/service/AuthService.java
+++ b/src/main/java/org/triumers/newsnippetback/Application/service/AuthService.java
@@ -18,5 +18,5 @@ public interface AuthService {
 
     void modifyUserInfo(UserDTO userDTO) throws UserNicknameDuplicateException, WrongInputTypeException;
 
-    void modifyPassword(PasswordDTO passwordDTO) throws WrongPasswordException;
+    void modifyPassword(PasswordDTO passwordDTO) throws WrongPasswordException, WrongInputTypeException;
 }

--- a/src/main/java/org/triumers/newsnippetback/Application/service/AuthServiceImpl.java
+++ b/src/main/java/org/triumers/newsnippetback/Application/service/AuthServiceImpl.java
@@ -39,8 +39,11 @@ public class AuthServiceImpl implements AuthService {
             throw new UserNicknameDuplicateException();
         }
 
-        // 닉네임 자릿수, 타입 검증
+        // 닉네임 유효성 검사
         validation.nickname(request.getNickname());
+
+        // 비밀번호 유효성 검사
+        validation.password(request.getPassword());
 
         // 이메일 중복 예외 처리
         if (userRepository.existsByEmail(request.getEmail())) {
@@ -83,8 +86,11 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public void modifyPassword(PasswordDTO passwordDTO) throws WrongPasswordException {
+    public void modifyPassword(PasswordDTO passwordDTO) throws WrongPasswordException, WrongInputTypeException {
         User user = userRepository.findByEmail(SecurityContextHolder.getContext().getAuthentication().getName());
+
+        // 비밀번호 유효성 검사
+        validation.password(passwordDTO.getNewPassword());
 
         if (bCryptPasswordEncoder.matches(passwordDTO.getOldPassword(), user.getPassword())) {
             user.setPassword(bCryptPasswordEncoder.encode(passwordDTO.getNewPassword()));

--- a/src/main/java/org/triumers/newsnippetback/common/exception/WrongInputTypeException.java
+++ b/src/main/java/org/triumers/newsnippetback/common/exception/WrongInputTypeException.java
@@ -1,0 +1,7 @@
+package org.triumers.newsnippetback.common.exception;
+
+public class WrongInputTypeException extends CustomException {
+    public WrongInputTypeException() {
+        super("유효하지 않은 입력입니다.");
+    }
+}

--- a/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthService.java
+++ b/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthService.java
@@ -1,29 +1,10 @@
 package org.triumers.newsnippetback.domain.service;
 
-import org.springframework.stereotype.Service;
 import org.triumers.newsnippetback.common.exception.WrongInputTypeException;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+public interface ValidationAuthService {
 
-@Service
-public class ValidationAuthService {
+    void nickname(String nickname) throws WrongInputTypeException;
 
-    public void nickname(String nickname) throws WrongInputTypeException {
-        Pattern pattern = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]{2,10}$");
-        Matcher matcher = pattern.matcher(nickname);
-
-        if (!matcher.matches()) {
-            throw new WrongInputTypeException();
-        }
-    }
-
-    public void password(String password) throws WrongInputTypeException {
-        Pattern pattern = Pattern.compile("^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{8,12}$");
-        Matcher matcher = pattern.matcher(password);
-
-        if (!matcher.matches()) {
-            throw new WrongInputTypeException();
-        }
-    }
+    void password(String password) throws WrongInputTypeException;
 }

--- a/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthService.java
+++ b/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthService.java
@@ -17,4 +17,13 @@ public class ValidationAuthService {
             throw new WrongInputTypeException();
         }
     }
+
+    public void password(String password) throws WrongInputTypeException {
+        Pattern pattern = Pattern.compile("^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{8,12}$");
+        Matcher matcher = pattern.matcher(password);
+
+        if (!matcher.matches()) {
+            throw new WrongInputTypeException();
+        }
+    }
 }

--- a/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthService.java
+++ b/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthService.java
@@ -1,0 +1,20 @@
+package org.triumers.newsnippetback.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.triumers.newsnippetback.common.exception.WrongInputTypeException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class ValidationAuthService {
+
+    public void nickname(String nickname) throws WrongInputTypeException {
+        Pattern pattern = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]{2,10}$");
+        Matcher matcher = pattern.matcher(nickname);
+
+        if (!matcher.matches()) {
+            throw new WrongInputTypeException();
+        }
+    }
+}

--- a/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthServiceImpl.java
+++ b/src/main/java/org/triumers/newsnippetback/domain/service/ValidationAuthServiceImpl.java
@@ -1,0 +1,31 @@
+package org.triumers.newsnippetback.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.triumers.newsnippetback.common.exception.WrongInputTypeException;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Service
+public class ValidationAuthServiceImpl implements ValidationAuthService {
+
+    @Override
+    public void nickname(String nickname) throws WrongInputTypeException {
+        Pattern pattern = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]{2,10}$");
+        Matcher matcher = pattern.matcher(nickname);
+
+        if (!matcher.matches()) {
+            throw new WrongInputTypeException();
+        }
+    }
+
+    @Override
+    public void password(String password) throws WrongInputTypeException {
+        Pattern pattern = Pattern.compile("^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])[a-zA-Z0-9]{8,12}$");
+        Matcher matcher = pattern.matcher(password);
+
+        if (!matcher.matches()) {
+            throw new WrongInputTypeException();
+        }
+    }
+}

--- a/src/test/java/org/triumers/newsnippetback/domain/service/ValidationAuthServiceTest.java
+++ b/src/test/java/org/triumers/newsnippetback/domain/service/ValidationAuthServiceTest.java
@@ -36,4 +36,33 @@ class ValidationAuthServiceTest {
     void wrongTypeNickname(String nickname) {
         assertThrows(WrongInputTypeException.class, () -> validation.nickname(nickname));
     }
+
+    @DisplayName("비밀번호 정상값 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"aA123456", "1234567890Zz", "aAbBcCdD123"})
+    void rightPassword(String password) throws WrongInputTypeException {
+
+        assertDoesNotThrow(() -> validation.password(password));
+    }
+
+    @DisplayName("비밀번호 길이 예외 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "aAbBcC1", "aAb1234567890"})
+    void wrongLengthPassword(String password) {
+        assertThrows(WrongInputTypeException.class, () -> validation.password(password));
+    }
+
+    @DisplayName("비밀번호 타입 예외 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"aA123456!@#", "테스트123456", "&123aaAAwWd"})
+    void wrongTypePassword(String password) {
+        assertThrows(WrongInputTypeException.class, () -> validation.password(password));
+    }
+
+    @DisplayName("비밀번호 소문자,대문자,숫자 한 개 이상 미포함 예외 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"aa123456", "AA123456", "aAbBcCdDeE"})
+    void wrongIncludePassword(String password) {
+        assertThrows(WrongInputTypeException.class, () -> validation.password(password));
+    }
 }

--- a/src/test/java/org/triumers/newsnippetback/domain/service/ValidationAuthServiceTest.java
+++ b/src/test/java/org/triumers/newsnippetback/domain/service/ValidationAuthServiceTest.java
@@ -1,0 +1,39 @@
+package org.triumers.newsnippetback.domain.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.triumers.newsnippetback.common.exception.WrongInputTypeException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class ValidationAuthServiceTest {
+
+    @Autowired
+    private ValidationAuthService validation;
+
+    @DisplayName("닉네임 정상값 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"테스트닉네임", "짧다", "일이삼사오육칠팔구십", "alpha123한글", "ㅁㄴㅇㅁㄴㅇ"})
+    void rightNickname(String nickname) throws WrongInputTypeException {
+
+        assertDoesNotThrow(() -> validation.nickname(nickname));
+    }
+
+    @DisplayName("닉네임 길이 예외 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"", "짧", "일이삼사오육칠팔구십넘었다"})
+    void wrongLengthNickname(String nickname) {
+        assertThrows(WrongInputTypeException.class, () -> validation.nickname(nickname));
+    }
+
+    @DisplayName("닉네임 타입 예외 테스트")
+    @ParameterizedTest
+    @ValueSource(strings = {"!@#", "테스트$%^", "&*()/\\"})
+    void wrongTypeNickname(String nickname) {
+        assertThrows(WrongInputTypeException.class, () -> validation.nickname(nickname));
+    }
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[x] 기능 추가  
-[ ] 기능 삭제  
-[ ] 버그 수정  
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
user -> dev

### 변경 사항
- 닉네임 유효성 검사 기능 구현
   - 2-10자
   - 알파벳, 한글, 숫자만 허용
- 비밀번호 유효성 검사 기능 구현
   - 8-12자
   - 알파벳, 숫자만 허용
   - 대문자, 소문자, 숫자 각각 한 개 이상 반드시 포함

### 테스트 결과
- 닉네임 정상값 테스트 통과
- 닉네임 길이 예외 테스트 통과
- 닉네임 특수문자 예외 테스트 통과
- 비밀번호 정상값 테스트 통과
- 비밀번호 길이 예외 테스트 통과
- 비밀번호 특수문자, 한글 예외 처리 통과
- 비밀번호 소문자, 대문자, 숫자 한 개 이상 미포함 예외처리 통과